### PR TITLE
Update CheckDiskAcccessPermissions to correctly check drives

### DIFF
--- a/Components/Checks/CheckDiskAcccessPermissions.cs
+++ b/Components/Checks/CheckDiskAcccessPermissions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -31,9 +31,10 @@ namespace DNN.Modules.SecurityAnalyzer.Components.Checks
         private static IList<string> CheckAccessToDrives()
         {
             var errors = new List<string>();
+            var dir = new DirectoryInfo(Globals.ApplicationMapPath);
             try
             {
-                var dir = new DirectoryInfo(Globals.ApplicationMapPath);
+
                 while (dir.Parent != null)
                 {
                     dir = dir.Parent;
@@ -43,9 +44,20 @@ namespace DNN.Modules.SecurityAnalyzer.Components.Checks
                         errors.Add(GetPermissionText(dir, permissions));
                     }
                 }
+            }
+            catch (IOException)
+            {
+                // e.g., a disk error or a drive was not ready
+            }
+            catch (UnauthorizedAccessException)
+            {
+                // The caller does not have the required permission.
+            }
 
-                var drives = DriveInfo.GetDrives();
-                foreach (var drive in drives.Where(d => d.IsReady && d.RootDirectory.Name != dir.Root.Name))
+            var drives = DriveInfo.GetDrives();
+            foreach (var drive in drives.Where(d => d.IsReady && d.RootDirectory.Name != dir.Root.Name))
+            {
+                try
                 {
                     var driveType = drive.DriveType;
                     if (driveType == DriveType.Fixed || driveType == DriveType.Network)
@@ -58,15 +70,16 @@ namespace DNN.Modules.SecurityAnalyzer.Components.Checks
                         }
                     }
                 }
+                catch (IOException)
+                {
+                    // e.g., a disk error or a drive was not ready
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // The caller does not have the required permission.
+                }
             }
-            catch (IOException)
-            {
-                // e.g., a disk error or a drive was not ready
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // The caller does not have the required permission.
-            }
+
             return errors;
         }
 

--- a/Components/Checks/CheckDiskAcccessPermissions.cs
+++ b/Components/Checks/CheckDiskAcccessPermissions.cs
@@ -32,26 +32,34 @@ namespace DNN.Modules.SecurityAnalyzer.Components.Checks
         {
             var errors = new List<string>();
             var dir = new DirectoryInfo(Globals.ApplicationMapPath);
-            try
+
+
+            while (dir.Parent != null)
             {
 
-                while (dir.Parent != null)
+                try
                 {
+
+
                     dir = dir.Parent;
                     var permissions = CheckPermissionOnDir(dir);
                     if (permissions.AnyYes)
                     {
                         errors.Add(GetPermissionText(dir, permissions));
                     }
+
+
                 }
-            }
-            catch (IOException)
-            {
-                // e.g., a disk error or a drive was not ready
-            }
-            catch (UnauthorizedAccessException)
-            {
-                // The caller does not have the required permission.
+                catch (IOException)
+                {
+                    // e.g., a disk error or a drive was not ready
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    // The caller does not have the required permission.
+
+                }
+
             }
 
             var drives = DriveInfo.GetDrives();


### PR DESCRIPTION
The code used a "Try" for exception handling on the access checks.
This "try" was for the whole procedure, both the check for current path and the individual drives.
This meant that when there was no access to to a folder down the tree from the current path, the drives check was skipped, giving a false sense of security. I added exception handling for each step going down the folder tree and one around each drive check.
After my initial pull request, I noticed that in principle while checking this path:
c:inpetpub/mywebsites/mywebsite, the "try" for the path was also in the wrong spot.
When the web user wouldn't have access to mywebsites, but would to the inetpub folder, the module would report both as safe.
I moved the error handling further down the procedure to wrap the check of the individual folders.
