### PR TITLE
Add DNN version check

### DIFF
--- a/App_LocalResources/View.ascx.resx
+++ b/App_LocalResources/View.ascx.resx
@@ -469,13 +469,16 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
     <value>Check</value>
   </data>
   <data name="CheckDnnVersionFailure.Text" xml:space="preserve">
-    <value>There are multiple major known security vulnerabilities in all versions of DNN Platform prior to DNN 9.x, please upgrade to the latest version of DNN Platform.  Warning, when upgrading, the Security Analyzer module should be uninstalled prior to an upgrade in order to prevent a possible incremental upgrade issue.</value>
+    <value>There are multiple major known security vulnerabilities in all versions of DNN Platform prior to DNN 9.x.</value>
   </data>
   <data name="CheckDnnVersionFailureNote.Text" xml:space="preserve">
-    <value>You are running a version of DNN before 9.x, you must upgrade DNN to address security vulnerabilities in your version of DNN.</value>
+    <value>You are running a version of DNN before 9.x, you must upgrade DNN to address security vulnerabilities in your version of DNN.  Warning, when upgrading, the Security Analyzer module should be uninstalled prior to an upgrade in order to prevent a possible incremental upgrade issue.</value>
   </data>
   <data name="CheckDnnVersionName.Text" xml:space="preserve">
     <value>Check if there are known major security vulnerabilities in this version of DNN</value>
+  </data>
+  <data name="CheckDnnVersionWarningNote.Text" xml:space="preserve">
+    <value>You are running DNN 9.x or later, this module is no longer being maintained and should be uninstalled. You can use the Security Analyzer included in the PersonaBar for security concerns with this version of DNN.</value>
   </data>
   <data name="CheckDnnVersionSuccess.Text" xml:space="preserve">
     <value>The version of DNN has no major known security vulnerabilities</value>

--- a/App_LocalResources/View.ascx.resx
+++ b/App_LocalResources/View.ascx.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -469,7 +469,7 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
     <value>Check</value>
   </data>
   <data name="CheckDnnVersionFailure.Text" xml:space="preserve">
-    <value>There are major known security vulnerabilities in all versions of DNN Platform up until DNN 9.x, please upgrade to the latest version of DNN Platform.  Once on DNN 9.x, uninstall the Security Analyzer module, it is replaced by the Security Persona Bar extension in DNN 9.x.</value>
+    <value>There are multiple major known security vulnerabilities in all versions of DNN Platform prior to DNN 9.x, please upgrade to the latest version of DNN Platform.  Warning, when upgrading, the Security Analyzer module should be uninstalled prior to an upgrade in order to prevent a possible incremental upgrade issue.</value>
   </data>
   <data name="CheckDnnVersionName.Text" xml:space="preserve">
     <value>Check if there are known major security vulnerabilities in this version of DNN</value>

--- a/App_LocalResources/View.ascx.resx
+++ b/App_LocalResources/View.ascx.resx
@@ -1,17 +1,17 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -238,7 +238,7 @@
     <value>viewstatemac validation is not enabled</value>
   </data>
   <data name="CheckViewstatemacReason.Text" xml:space="preserve">
-    <value>A view-state MAC is an encrypted version of the hidden variable that a page's view state is persisted to when the page is sent to the browser. When this property is set to true, the encrypted view state is checked to verify that it has not been tampered with on the client. 
+    <value>A view-state MAC is an encrypted version of the hidden variable that a page's view state is persisted to when the page is sent to the browser. When this property is set to true, the encrypted view state is checked to verify that it has not been tampered with on the client.
 </value>
   </data>
   <data name="CheckViewstatemacSuccess.Text" xml:space="preserve">
@@ -471,11 +471,11 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
   <data name="CheckDnnVersionFailure.Text" xml:space="preserve">
     <value>There are multiple major known security vulnerabilities in all versions of DNN Platform prior to DNN 9.x, please upgrade to the latest version of DNN Platform.  Warning, when upgrading, the Security Analyzer module should be uninstalled prior to an upgrade in order to prevent a possible incremental upgrade issue.</value>
   </data>
+  <data name="CheckDnnVersionFailureNote.Text" xml:space="preserve">
+    <value>You are running a version of DNN before 9.x, you must upgrade DNN to address security vulnerabilities in your version of DNN.</value>
+  </data>
   <data name="CheckDnnVersionName.Text" xml:space="preserve">
     <value>Check if there are known major security vulnerabilities in this version of DNN</value>
-  </data>
-  <data name="CheckDnnVersionReason.Text" xml:space="preserve">
-    <value>This module should only be used before DNN 9.x, and every version of DNN before 9.x has known major security vulnerabilities.</value>
   </data>
   <data name="CheckDnnVersionSuccess.Text" xml:space="preserve">
     <value>The version of DNN has no major known security vulnerabilities</value>

--- a/App_LocalResources/View.ascx.resx
+++ b/App_LocalResources/View.ascx.resx
@@ -468,4 +468,16 @@ If you expect this addition, then just ignore this email; otherwise, an immediat
   <data name="Check.Text" xml:space="preserve">
     <value>Check</value>
   </data>
+  <data name="CheckDnnVersionFailure.Text" xml:space="preserve">
+    <value>There are major known security vulnerabilities in all versions of DNN Platform up until DNN 9.x, please upgrade to the latest version of DNN Platform.  Once on DNN 9.x, uninstall the Security Analyzer module, it is replaced by the Security Persona Bar extension in DNN 9.x.</value>
+  </data>
+  <data name="CheckDnnVersionName.Text" xml:space="preserve">
+    <value>Check if there are known major security vulnerabilities in this version of DNN</value>
+  </data>
+  <data name="CheckDnnVersionReason.Text" xml:space="preserve">
+    <value>This module should only be used before DNN 9.x, and every version of DNN before 9.x has known major security vulnerabilities.</value>
+  </data>
+  <data name="CheckDnnVersionSuccess.Text" xml:space="preserve">
+    <value>The version of DNN has no major known security vulnerabilities</value>
+  </data>
 </root>

--- a/Components/AuditChecks.cs
+++ b/Components/AuditChecks.cs
@@ -15,6 +15,7 @@ namespace DNN.Modules.SecurityAnalyzer.Components
         {
             var checks = new List<IAuditCheck>
             {
+                new CheckDnnVersion(),
                 new CheckDebug(),
                 new CheckTracing(),
                 new CheckBiography(),

--- a/Components/Checks/CheckDnnVersion.cs
+++ b/Components/Checks/CheckDnnVersion.cs
@@ -1,21 +1,30 @@
 ﻿namespace DNN.Modules.SecurityAnalyzer.Components.Checks
 {
     using DotNetNuke.Application;
+    using DotNetNuke.Services.Localization;
 
     public class CheckDnnVersion : IAuditCheck
     {
+        private const string ResourceFileRoot = "~/DesktopModules/DNNCorp/SecurityAnalyzer/App_LocalResources/View.ascx";
+
         public string Id => "CheckDnnVersion";
 
         public bool LazyLoad => false;
 
         public CheckResult Execute()
         {
-            if (DotNetNukeContext.Current.Application.Version.Major < 9)
-            {
-                return new CheckResult(SeverityEnum.Failure, Id);
-            }
+            const int KnownCompromisedVersion = 8;
+            var severity = DotNetNukeContext.Current.Application.Version.Major <= KnownCompromisedVersion
+                ? SeverityEnum.Failure
+                : SeverityEnum.Warning;
 
-            return new CheckResult(SeverityEnum.Warning, Id);
+            return new CheckResult(severity, Id)
+                   {
+                       Notes =
+                       {
+                           Localization.GetString("CheckDnnVersion" +  severity + "Note", ResourceFileRoot),
+                       }
+                   };
         }
     }
 }

--- a/Components/Checks/CheckDnnVersion.cs
+++ b/Components/Checks/CheckDnnVersion.cs
@@ -1,0 +1,21 @@
+﻿namespace DNN.Modules.SecurityAnalyzer.Components.Checks
+{
+    using DotNetNuke.Application;
+
+    public class CheckDnnVersion : IAuditCheck
+    {
+        public string Id => "CheckDnnVersion";
+
+        public bool LazyLoad => false;
+
+        public CheckResult Execute()
+        {
+            if (DotNetNukeContext.Current.Application.Version.Major < 9)
+            {
+                return new CheckResult(SeverityEnum.Failure, Id);
+            }
+
+            return new CheckResult(SeverityEnum.Warning, Id);
+        }
+    }
+}

--- a/DNN.Modules.SecurityAnalyzer.csproj
+++ b/DNN.Modules.SecurityAnalyzer.csproj
@@ -21,6 +21,7 @@
     <IISExpressUseClassicPipelineMode />
     <TargetFrameworkProfile />
     <UseGlobalApplicationHostFile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Components\AuditChecks.cs" />
     <Compile Include="Components\CheckResult.cs" />
+    <Compile Include="Components\Checks\CheckDnnVersion.cs" />
     <Compile Include="Components\Checks\CheckAllowableFileExtensions.cs" />
     <Compile Include="Components\Checks\CheckHiddenSystemFiles.cs" />
     <Compile Include="Components\Checks\CheckHttpModules.cs" />


### PR DESCRIPTION
### Description of PR...
This PR adds a new check, for the version of DNN.  Only the latest version of DNN, 9.2.2, is free of major known vulnerabilities, the Security Analyzer should indicate that an upgrade is required for users on older versions of the Platform.

## Changes made
Added a check which gives an error before DNN 9, indicating that an upgrade is needed.  The check gives a warning in DNN 9+, indicating that you should migrate to the Security extension in the Persona Bar.

Here's what it looks like in DNN 7.4.2:
![DNN 7.4.2 Security Analyzer](https://user-images.githubusercontent.com/59507/47390490-257f0d00-d6dd-11e8-8013-fcfe8bfe748c.png)

## PR Template Checklist

- [ ] Fixes Bug
- [x] Feature solution
- [ ] Other

Closes #40 